### PR TITLE
chore: rename repo from nz-imagery-surveys to nz-aerial-survey-indexes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,9 @@
-==================
-NZ Imagery Surveys
-==================
+=========================
+NZ Aerial Imagery Indexes
+=========================
 
-.. image:: https://github.com/linz/nz-imagery-surveys/workflows/Build/badge.svg
-    :target: https://github.com/linz/nz-imagery-surveys/actions
+.. image:: https://github.com/linz/nz-aerial-survey-indexes/workflows/Build/badge.svg
+    :target: https://github.com/linz/nz-aerial-survey-indexes/actions
     :alt: CI Status
 
 .. image:: https://readthedocs.org/projects/nz-imagery-surveys/badge/?version=latest
@@ -11,7 +11,7 @@ NZ Imagery Surveys
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/badge/License-BSD%203--Clause-blue.svg 
-    :target: https://github.com/linz/nz-imagery-surveys/blob/master/LICENSE
+    :target: https://github.com/linz/nz-aerial-survey-indexes/blob/master/LICENSE
     :alt: License
 
 Provides the schema and documentation for the Imagery Surveys dataset.


### PR DESCRIPTION
Fixes: #62

### Change Description:

Rename repo from NZ Imagery Surveys to NZ Aerial Survey Indexes to reflect the fact that it contains more than just imagery surveys now (with elevation surveys and tile indexes too).

### Notes for Testing:

Unchanged.. CI should still work.

#### Source Code Documentation Tasks:
- [x] README updated (where applicable)
- [ ] CHANGELOG (Unreleased section) updated
- [ ] Docstrings / comments included to help explain code

#### User Documentation Tasks:
- [ ] Confluence user guide updated (where applicable)

#### Testing Tasks:
- [ ] Added tests that fail without this change
- [ ] All tests are passing in development environment
- [ ] Reviewers assigned
- [ ] Linked to main issue for ZenHub board
